### PR TITLE
Update domain references in SEO components and documentation

### DIFF
--- a/seo_plan.md
+++ b/seo_plan.md
@@ -25,7 +25,7 @@ Vercel automatically sets `x-robots-tag: noindex` **for preview deployments**.
 Production deployments _on the main branch_ are not affected, but double-check:
 
 ```bash
-curl -I https://relationships-tests.vercel.app/
+curl -I https://bachatapp.vercel.app/
 # Ensure there is NO `x-robots-tag: noindex`
 ```
 
@@ -192,6 +192,6 @@ Optimise images (next-gen formats, lazy-load), bundle size (code-splitting), and
 
 1. Configure custom domain in Vercel (if desired)
 2. ~~Verify site in Google Search Console and submit sitemap~~
-3. Run Lighthouse to check Core Web Vitals
+3. ~~Run Lighthouse to check Core Web Vitals~~
 
 **Once all checkmarks are green, Google can crawl, index, and rank your site. 🚀**

--- a/src/components/common/SEO.tsx
+++ b/src/components/common/SEO.tsx
@@ -11,7 +11,7 @@ interface SEOProps {
 }
 
 // Base domain for canonical URLs and OG tags
-const baseUrl = 'https://relationships-tests.vercel.app';
+const baseUrl = 'https://bachatapp.vercel.app';
 
 export const SEO: React.FC<SEOProps> = ({
   title = 'Bachata App - Learn Bachata History, Music & Dance',

--- a/src/components/common/StructuredData.tsx
+++ b/src/components/common/StructuredData.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { Helmet } from 'react-helmet-async';
 
 // Base URL for links in structured data
-const baseUrl = 'https://relationships-tests.vercel.app';
+const baseUrl = 'https://bachatapp.vercel.app';
 
 interface StructuredDataProps {
   type: 'home' | 'section' | 'lesson' | 'quiz' | 'glossary';

--- a/vercel.json
+++ b/vercel.json
@@ -11,10 +11,10 @@
       "has": [
         {
           "type": "host",
-          "value": "www.relationships-tests.vercel.app"
+          "value": "www.bachatapp.vercel.app"
         }
       ],
-      "destination": "https://relationships-tests.vercel.app",
+      "destination": "https://bachatapp.vercel.app",
       "permanent": true
     }
   ],


### PR DESCRIPTION
- Changed all instances of the old domain 'https://relationships-tests.vercel.app' to the new domain 'https://bachatapp.vercel.app' in seo_plan.md, vercel.json, and SEO/StructuredData components for consistency.
- Marked the Lighthouse check as completed in the SEO plan for clarity.