### PR TITLE
Add redirect rule for new domain in vercel.json

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -7,6 +7,17 @@
   ],
   "redirects": [
     {
+      "source": "/(.*)",
+      "has": [
+        {
+          "type": "host",
+          "value": "bachatapp.vercel.app"
+        }
+      ],
+      "destination": "https://bachatapp.org/$1",
+      "permanent": true
+    },
+    {
       "source": "/",
       "has": [
         {


### PR DESCRIPTION
- Implemented a redirect from bachatapp.vercel.app to bachatapp.org to ensure users are seamlessly directed to the updated site.
- This change enhances user experience by maintaining access to content under the new domain.